### PR TITLE
Update library reference to reflect changes made in Django 1.6

### DIFF
--- a/banner_rotator/admin.py
+++ b/banner_rotator/admin.py
@@ -1,6 +1,7 @@
 #-*- coding:utf-8 -*-
 
 import logging
+from functools import update_wrapper
 
 from django import forms, template
 from django.contrib import admin
@@ -8,7 +9,6 @@ from django.contrib.admin.util import unquote
 from django.db import models
 from django.shortcuts import get_object_or_404, render_to_response
 from django.utils.encoding import force_unicode
-from django.utils.functional import update_wrapper
 from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 


### PR DESCRIPTION
The update_wrapper function import was removed in Django 1.6.

Reference: https://github.com/kezabelle/django-haystackbrowser/issues/5
Code: https://github.com/django/django/commit/876fc3912881e15eda2b02c3b4933af313d0a498
Documentation: https://docs.python.org/2/library/functools.html#functools.update_wrapper
